### PR TITLE
Fix validateFileType method to correctly validate heic and m4v files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-type-checker",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "Detect and validate file types by their signatures (✨magic numbers✨)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/core/file-types/index.ts
+++ b/src/core/file-types/index.ts
@@ -21,6 +21,7 @@ export const FILE_TYPES_REQUIRED_ADDITIONAL_CHECK: Array<string> = [
   "mkv",
   "webm",
   "avif",
+  "heic",
 ];
 
 /**
@@ -166,7 +167,7 @@ export class FileTypes {
         return "heic";
       const isFlv = isFLV(fileChunk);
       if (isFlv) return "flv";
-      const isM4v = isM4V(fileChunk);
+      const isM4v = isM4V(fileChunk) && !isHEIC(fileChunk);
       if (isM4v) return "m4v";
       return "mp4";
     } else if (detectedExtensions.some((de) => ["mkv", "webm"].includes(de))) {

--- a/test/validation/validation.spec.ts
+++ b/test/validation/validation.spec.ts
@@ -297,3 +297,29 @@ describe("validateFileType", () => {
     expect(detectedFile).toBeFalsy();
   });
 });
+
+it("should return false when validating an m4v file signature that shares the same signature as a heic file, with only 'heic' as the accepted type", () => {
+  const fileArrayNumber: Array<number> = [
+    0, 0, 0, 0, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x70, 0x34, 0x32, 0, 0, 0, 32,
+    102, 116, 121, 112, 77, 52, 86, 72, 0, 0, 0, 1, 77, 52, 86, 72, 77, 52, 65,
+    32, 109, 112, 52, 50, 105, 115, 111, 109,
+  ];
+
+  const isM4v: boolean = fileTypeChecker.validateFileType(fileArrayNumber, [
+    "heic",
+  ]);
+  expect(isM4v).toBeFalsy();
+});
+
+it("should return true when validating an m4v file signature with 'm4v' as the accepted type", () => {
+  const fileArrayNumber: Array<number> = [
+    0, 0, 0, 0, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x70, 0x34, 0x32, 0, 0, 0, 32,
+    102, 116, 121, 112, 77, 52, 86, 72, 0, 0, 0, 1, 77, 52, 86, 72, 77, 52, 65,
+    32, 109, 112, 52, 50, 105, 115, 111, 109,
+  ];
+
+  const isM4v: boolean = fileTypeChecker.validateFileType(fileArrayNumber, [
+    "m4v",
+  ]);
+  expect(isM4v).toBeTruthy();
+});


### PR DESCRIPTION
Resolves #9